### PR TITLE
Image chooser workaround

### DIFF
--- a/src/models/MainWindowModel.cs
+++ b/src/models/MainWindowModel.cs
@@ -4,19 +4,27 @@ namespace Filters.Models
 {
     public class MainWindowModel : ReactiveObject
     {
-        // Properties
+        // Path for the image
         private string path;
-
         public string Path
         {
             get => path;
             set => this.RaiseAndSetIfChanged(ref path, value);
         }
 
+        // True for manual input for the path
+        private bool isManual;
+        public bool IsManual
+        {
+            get => isManual;
+            set => this.RaiseAndSetIfChanged(ref isManual, value);
+        }
+
         /// <summary>Constructor</summary>
         public MainWindowModel()
         {
             path = "No image. Please select one.";
+            isManual = false;
         }
     }
 }

--- a/src/views/App.xaml.cs
+++ b/src/views/App.xaml.cs
@@ -27,5 +27,5 @@ namespace Filters.Views
 
             base.OnFrameworkInitializationCompleted();
         }
-   }
+    }
 }

--- a/src/views/main/MainWindow.xaml
+++ b/src/views/main/MainWindow.xaml
@@ -52,13 +52,17 @@
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
-                        <RadioButton Content="File Chooser"
+                        <RadioButton Click="SelectChooseMethod"
+                                     Content="File Chooser"
                                      Grid.Column="0"
                                      HorizontalAlignment="Center"
-                                     IsChecked="True" />
-                        <RadioButton Content="Manual Write"
+                                     IsChecked="True"
+                                     Name="Chooser"/>
+                        <RadioButton Click="SelectChooseMethod"
+                                     Content="Manual Write"
                                      Grid.Column="1"
-                                     HorizontalAlignment="Center" />
+                                     HorizontalAlignment="Center"
+                                     Name="Manual"/>
                     </Grid>
                     <Grid>
                         <Grid.ColumnDefinitions>
@@ -68,8 +72,10 @@
                         <Button Click="ChooseImage"
                                 Content="Choose Image"
                                 Grid.Column="0"
+                                IsVisible="{Binding !IsManual}"
                                 Margin="10" />
                         <TextBox Grid.Column="1"
+                                 IsReadOnly="{Binding !IsManual}"
                                  Margin="0,0,75,0"
                                  VerticalAlignment="Center"
                                  Text="{Binding Path}" />

--- a/src/views/main/MainWindow.xaml
+++ b/src/views/main/MainWindow.xaml
@@ -43,6 +43,23 @@
             <Border Classes="Card"
                     Padding="3">
                 <StackPanel>
+                    <TextBlock
+                               HorizontalAlignment="Center"
+                               Margin="5"
+                               Text="Select the way to chose the image." />
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <RadioButton Content="File Chooser"
+                                     Grid.Column="0"
+                                     HorizontalAlignment="Center"
+                                     IsChecked="True" />
+                        <RadioButton Content="Manual Write"
+                                     Grid.Column="1"
+                                     HorizontalAlignment="Center" />
+                    </Grid>
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="0.15*" />
@@ -52,12 +69,10 @@
                                 Content="Choose Image"
                                 Grid.Column="0"
                                 Margin="10" />
-                        <TextBlock Classes="Caption"
-                                   Grid.Column="1"
-                                   HorizontalAlignment="Left"
-                                   Margin="10"
-                                   VerticalAlignment="Center"
-                                   Text="{Binding Path}" />
+                        <TextBox Grid.Column="1"
+                                 Margin="0,0,75,0"
+                                 VerticalAlignment="Center"
+                                 Text="{Binding Path}" />
                     </Grid>
                     <Grid>
                         <Grid.ColumnDefinitions>

--- a/src/views/main/MainWindow.xaml.cs
+++ b/src/views/main/MainWindow.xaml.cs
@@ -46,5 +46,19 @@ namespace Filters.Views.Main
         {
             AvaloniaXamlLoader.Load(this);
         }
+
+        /// <summary>Display the controls based on the option selected</summary>
+        /// <param name="sender">The object that raised the event</param>
+        /// <param name="e">The object that is being handled</param>
+        private void SelectChooseMethod(object sender, RoutedEventArgs e)
+        {
+            RadioButton radioButton = sender as RadioButton;
+            MainWindowModel context = DataContext as MainWindowModel;
+
+            if (radioButton.Name.Equals("Manual"))
+                context.IsManual = true;
+            else
+                context.IsManual = false;
+        }
     }
 }


### PR DESCRIPTION
Add radio buttons that show or hide the `Choose Image` button also to make readonly or not the textbox for the path.

Solves #7 
Implements #8 